### PR TITLE
Restore if spy has been created

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ function onPrototype (Component, lifecycle, method) {
 
 function spyLifeCycle(Component) {
   onPrototype(Component, function(proto, name) {
+    if (proto[name].isSinonProxy) {
+      proto[name].restore()
+    }
     sinon.spy(proto, name)
   })
 }


### PR DESCRIPTION
Hey @fraserxu,

I used `spyLifeCycle` for each test case, but currently it need to restore lifecycle functions yourself, I think restore it if `spy.isSinonProxy` will be better.
